### PR TITLE
Auto-build JsonArrayBuilder or JsonObjectBuilders when used as JsonVa…

### DIFF
--- a/joy/src/main/java/org/leadpony/joy/internal/JsonValues.java
+++ b/joy/src/main/java/org/leadpony/joy/internal/JsonValues.java
@@ -110,6 +110,10 @@ final class JsonValues {
             @SuppressWarnings("unchecked")
             Map<String, ?> map = (Map<String, ?>) value;
             return new JsonObjectBuilderImpl(map).build();
+        } else if (value instanceof JsonArrayBuilder) {
+            return ((JsonArrayBuilder) value).build();
+        } else if (value instanceof JsonObjectBuilder) {
+            return ((JsonObjectBuilder) value).build();
         }
         throw new IllegalArgumentException(
             Message.JSON_VALUE_UNSUPPORTED_TYPE.with(value.getClass().getName()));


### PR DESCRIPTION
…lues

In the builder patterns that I've used, using a builder inside another builder is fine and calling `build()` on the outer object automatically calls build on inner ones. This change would do the same thing for the `JsonArrayBuilder` and `JsonObjectBuilder`. It basically allows the two builders to be coerced into a `JsonValue` in the same way that a Collection or `Map` can be.