### PR TITLE
JsonObject::getBoolean should throw NPE if it doesn't contain the value

### DIFF
--- a/joy-core/src/main/java/org/leadpony/joy/core/JsonObjectImpl.java
+++ b/joy-core/src/main/java/org/leadpony/joy/core/JsonObjectImpl.java
@@ -115,6 +115,9 @@ class JsonObjectImpl extends AbstractMap<String, JsonValue> implements JsonObjec
     @Override
     public boolean getBoolean(String name) {
         JsonValue value = get(name);
+        if (value == null) {
+            throw new NullPointerException();
+        }
         if (value == JsonValue.TRUE) {
             return true;
         } else if (value == JsonValue.FALSE) {


### PR DESCRIPTION
Fixes #9